### PR TITLE
Forward host env vars into pooled sessions (`[remote] inherit_env`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,6 +362,8 @@ on_window_close = "close"    # "close" | "detach": what closing a pooled session
                              # does to the session. Only a window *you* close counts — an
                              # attach that ends because its link died (a laptop resuming to
                              # a dropped ssh) always detaches, and the session keeps running.
+inherit_env = []           # list of host environment variable names to forward to
+                           # pooled sessions (e.g. ["ANTHROPIC_API_KEY"])
 
 [thresholds]
 context_warning_tokens = 175000    # context usage turns to the warning color here

--- a/crates/cm-core/src/config.rs
+++ b/crates/cm-core/src/config.rs
@@ -62,6 +62,7 @@ pub fn config_path() -> PathBuf {
 pub struct CoreConfig {
     pub launcher: LauncherConfig,
     pub debug: DebugConfig,
+    pub remote: RemoteConfig,
 }
 
 impl CoreConfig {
@@ -225,9 +226,48 @@ impl Default for DebugConfig {
     }
 }
 
+// =============================================================================
+// remote
+// =============================================================================
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default)]
+/// `[remote]` in `config.toml`: knobs for sessions this dashboard reaches over
+/// a `miao-server` (ssh or pooled-localhost).
+pub struct RemoteConfig {
+    /// Names of environment variables a pooled session should **inherit from
+    /// the remote host** it runs on. libshpool's pty pool starts every session
+    /// with a scrubbed environment (`env_clear`), so a container-level secret
+    /// like `ANTHROPIC_API_KEY` — present for a plain interactive shell —
+    /// otherwise never reaches the agent. Each name here is threaded to
+    /// `miao-server attach` (`--inherit-env`), which hands it to libshpool's
+    /// `forward_env`: the value is read live from the attach process's own
+    /// environment on the host (never the dashboard's, never disk) and injected
+    /// into the session. Empty by default — opt in per var, since forwarding a
+    /// secret is a deliberate act.
+    pub inherit_env: Vec<String>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn remote_inherit_env_parses() {
+        let cfg: CoreConfig =
+            toml::from_str("[remote]\ninherit_env = [\"ANTHROPIC_API_KEY\", \"OPENAI_API_KEY\"]\n")
+                .unwrap();
+        assert_eq!(
+            cfg.remote.inherit_env,
+            ["ANTHROPIC_API_KEY", "OPENAI_API_KEY"]
+        );
+    }
+
+    #[test]
+    fn remote_inherit_env_defaults_empty() {
+        let cfg = CoreConfig::default();
+        assert!(cfg.remote.inherit_env.is_empty());
+    }
 
     #[test]
     fn legacy_literal_titles_migrate_to_default() {

--- a/crates/cm-server/src/main.rs
+++ b/crates/cm-server/src/main.rs
@@ -122,6 +122,13 @@ enum Commands {
         /// `io::empty()`, making a failed create undebuggable.
         #[arg(long)]
         log_file: Option<String>,
+        /// Environment variable NAMES the pooled session should inherit from
+        /// this host. Threaded from the dashboard's `[remote] inherit_env`;
+        /// each becomes a libshpool `forward_env` entry, so the value is read
+        /// live from this attach process's own environment (the container's
+        /// env) and injected into the otherwise-scrubbed pool session.
+        #[arg(long = "inherit-env")]
+        inherit_env: Vec<String>,
     },
 
     /// Clipboard-bridge helpers for the machine an agent runs on.
@@ -287,7 +294,8 @@ fn main() -> Result<()> {
             background,
             force,
             log_file,
-        } => return pty_pool::run_attach(name, cmd, dir, background, force, log_file),
+            inherit_env,
+        } => return pty_pool::run_attach(name, cmd, dir, background, force, log_file, inherit_env),
         _ => {}
     }
 

--- a/crates/cm-server/src/pty_pool.rs
+++ b/crates/cm-server/src/pty_pool.rs
@@ -79,6 +79,51 @@ fn write_pool_config() -> Result<PathBuf> {
     Ok(path)
 }
 
+/// The libshpool config captain-miao authors for the **attach client** in a
+/// pooled session, from `--inherit-env`. It carries **only** `forward_env` —
+/// the env-var *names* the attach should forward from its own environment into
+/// the pool session the *first time* that session is created. The attach
+/// client runs on the remote host in the container (it is what the dashboard's
+/// `ssh miao-server attach` lands on), so it can read each value live from the
+/// container env and ship it to the daemon — piercing libshpool's `env_clear`
+/// scrub for the handful of names a container sets that the session needs.
+///
+/// Deliberately **not** the daemon-side [`POOL_CONFIG`]: that file governs
+/// session-restore and keybinding, which are daemon concerns and must stay
+/// there. `forward_env` alone belongs here because it is a property of the
+/// attach path, not the daemon.
+fn attach_config_body(names: &[String]) -> String {
+    format!(
+        "forward_env = [{}]\n",
+        names
+            .iter()
+            .map(|n| format!("{n:?}"))
+            .collect::<Vec<_>>()
+            .join(", ")
+    )
+}
+
+/// Path to the per-session libshpool attach config. Namespaced by session
+/// (`attach-config-<name>.toml`) so two concurrent attaches to different
+/// sessions never race on one file, and regenerated on every attach.
+fn attach_config_path(name: &str) -> PathBuf {
+    crate::state::runtime_dir().join(format!("attach-config-{name}.toml"))
+}
+
+/// Write [`attach_config_body`] to [`attach_config_path`] and return the path
+/// (to pass via `--config-file`). Mirror of [`write_pool_config`]: the file has
+/// to exist before libshpool runs, else it silently falls back to default and
+/// no env is forwarded.
+fn write_attach_config(name: &str, names: &[String]) -> Result<String> {
+    let path = attach_config_path(name);
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(&path, attach_config_body(names))
+        .with_context(|| format!("write attach config {}", path.display()))?;
+    Ok(path.display().to_string())
+}
+
 /// True if a pty-daemon is already listening on `socket`. A bare connect is
 /// enough: it's captain-miao's private socket in its per-user runtime dir, so
 /// anything that accepts a connection there is our daemon. This is the liveness
@@ -438,6 +483,7 @@ pub(crate) fn run_attach(
     background: bool,
     force: bool,
     log_file: Option<String>,
+    inherit_env: Vec<String>,
 ) -> Result<()> {
     let (mut cmd, mut dir, mut log_file) = (cmd, dir, log_file);
     let mut prime = cm_core::state::ReattachPrime::default();
@@ -482,6 +528,23 @@ pub(crate) fn run_attach(
     if let Some(lf) = &log_file {
         global.push("--log-file");
         global.push(lf);
+    }
+    // When the dashboard asks for inherited env, author an attach config
+    // carrying `forward_env` and hand libshpool the path. The file must exist
+    // before `run_shpool` (it coalesces-style *skips* a missing config), and
+    // the pushed `&str` must outlive the call — `attach_cfg` owns the String,
+    // so the config path stays alive until `run_shpool` returns. The value of
+    // each name is read live from *this* process's env (the container's) on the
+    // host side, so it reaches a freshly-created session without sitting in
+    // `POOL_CONFIG` or the dashboard.
+    let attach_cfg = if !inherit_env.is_empty() {
+        Some(write_attach_config(&name, &inherit_env)?)
+    } else {
+        None
+    };
+    if let Some(cfg) = &attach_cfg {
+        global.push("--config-file");
+        global.push(cfg);
     }
     let mut sub: Vec<&str> = vec!["attach"];
     if background {
@@ -638,6 +701,29 @@ mod tests {
             !POOL_CONFIG.contains("[[keybinding]]"),
             "authored config: {POOL_CONFIG:?}"
         );
+    }
+
+    #[test]
+    fn attach_config_body_lists_forward_env() {
+        // The attach config exists to carry `forward_env`; each requested name
+        // becomes one quoted list element. It must not smuggle in the
+        // daemon-side session-restore/keybinding knobs — those belong to
+        // `POOL_CONFIG`, and a stray key here would override (or conflict with)
+        // what the daemon was told.
+        let body = attach_config_body(&["ANTHROPIC_API_KEY".into(), "OPENAI_API_KEY".into()]);
+        assert_eq!(
+            body,
+            "forward_env = [\"ANTHROPIC_API_KEY\", \"OPENAI_API_KEY\"]\n"
+        );
+        assert!(!body.contains("session_restore_mode"));
+        assert!(!body.contains("keybinding"));
+    }
+
+    #[test]
+    fn attach_config_body_empty_is_empty_array() {
+        // An empty forbid-list yields a valid (empty) TOML array, not a comment
+        // or a bare line — libshpool must see a defined `forward_env`.
+        assert_eq!(attach_config_body(&[]), "forward_env = []\n");
     }
 
     #[test]

--- a/docs/remote-sessions.md
+++ b/docs/remote-sessions.md
@@ -188,6 +188,18 @@ library**.
   `header.cmd` branch) — so the test also pins that `join` → `split` round-trips.
   (The `{`/`}` ban is separate and still real: libshpool runs the string through
   its session-name *template* parser before that.)
+- **Arbitrary host env vars reach the session through `[remote] inherit_env`.**
+  The `COLORTERM` note above hard-codes one var because every attaching terminal
+  supports it; a *secret* like `ANTHROPIC_API_KEY` can't be hard-coded, so it
+  rides libshpool's `forward_env` instead. The dashboard threads each configured
+  name to `miao-server attach` as a `--inherit-env <NAME>` flag; `run_attach`
+  authors a per-session config carrying `forward_env = [names]` and passes it via
+  `--config-file` (the attach path did not load a config before, so this is also
+  the plumbing that makes `forward_env` reachable at all). libshpool then reads
+  each value **live from the attach client's own environment** — which runs on
+  the host, so it is the *host/container* env that is forwarded, not the
+  laptop's — and injects it into the otherwise-scrubbed session. Opt-in and empty
+  by default: forwarding a secret is deliberate, and the value never touches disk.
 - **OSC 52 (clipboard) works end-to-end.** libshpool's live relay is a
   transparent byte pipe — its source contains no OSC handling at all (the
   vterm engine exists only for the `screen`/`lines` restore buffer, unused in

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1189,6 +1189,7 @@ impl Backend {
         session_name: &str,
         force: bool,
     ) -> anyhow::Result<AttachPlan> {
+        let inherit_env = cm_core::config::get().remote.inherit_env.clone();
         match self {
             // A direct-local backend pools nothing *itself*, but the machine it
             // runs on may still hold a pool — the daemon serving a laptop's
@@ -1198,7 +1199,7 @@ impl Backend {
             // but "can this machine reach its own pool", and the caller has
             // already established that the row carries a `pool_session` at all.
             Backend::Local(_) => Ok(AttachPlan {
-                argv: local_attach_argv(session_name, force)?,
+                argv: local_attach_argv(session_name, force, &inherit_env)?,
             }),
             Backend::Remote(b) => Ok(AttachPlan {
                 argv: attach_argv(
@@ -1207,6 +1208,7 @@ impl Backend {
                     &b.remote_exe.lock().unwrap(),
                     session_name,
                     force,
+                    &inherit_env,
                 ),
             }),
         }
@@ -1918,6 +1920,7 @@ impl RemoteBackend {
     /// so an async caller should wrap this in `block_in_place`.
     fn open_session(&self, spec: &OpenSpec) -> anyhow::Result<LaunchPlan> {
         let spec = spec.clone();
+        let inherit_env = cm_core::config::get().remote.inherit_env.clone();
         match self.request(|req_id| ClientFrame::OpenSession { req_id, spec }) {
             Some(ServerFrame::Opened {
                 session_name: Some(name),
@@ -1931,6 +1934,7 @@ impl RemoteBackend {
                     // A session we just created can't already have a client, so
                     // the create path never steals.
                     false,
+                    &inherit_env,
                 ),
                 session_name: name,
             }),
@@ -2143,6 +2147,7 @@ fn attach_argv(
     remote_exe: &str,
     session_name: &str,
     force: bool,
+    inherit_env: &[String],
 ) -> Vec<String> {
     let mut argv = match target {
         Some(t) => {
@@ -2157,6 +2162,10 @@ fn attach_argv(
     argv.push("attach".to_string());
     if force {
         argv.push("--force".to_string());
+    }
+    for name in inherit_env {
+        argv.push("--inherit-env".to_string());
+        argv.push(name.clone());
     }
     argv.push(session_name.to_string());
     argv
@@ -2180,7 +2189,11 @@ const LOCAL_ATTACH_EXES: [&str; 2] = ["miao-client", "miao-server"];
 /// target), because it is the same operation: the pool is a per-user,
 /// per-machine socket, so what reaches it is a question about the binaries on
 /// this box and not about which backend happens to be drawing the row.
-fn local_attach_argv(session_name: &str, force: bool) -> anyhow::Result<Vec<String>> {
+fn local_attach_argv(
+    session_name: &str,
+    force: bool,
+    inherit_env: &[String],
+) -> anyhow::Result<Vec<String>> {
     let exe = local_attach_exe(session_name).ok_or_else(|| {
         anyhow::anyhow!(
             "no pool client on this machine — install {} beside `miao` or on PATH",
@@ -2191,7 +2204,14 @@ fn local_attach_argv(session_name: &str, force: bool) -> anyhow::Result<Vec<Stri
                 .join(" or ")
         )
     })?;
-    Ok(attach_argv(None, &[], &exe, session_name, force))
+    Ok(attach_argv(
+        None,
+        &[],
+        &exe,
+        session_name,
+        force,
+        inherit_env,
+    ))
 }
 
 /// The binary to run for an attach to `session_name` on this machine.
@@ -3866,7 +3886,7 @@ mod tests {
 
     #[test]
     fn attach_argv_ssh_vs_direct() {
-        let ssh = attach_argv(Some("user@box"), &[], "miao-server", "s1", false);
+        let ssh = attach_argv(Some("user@box"), &[], "miao-server", "s1", false, &[]);
         assert_eq!(ssh[0], "ssh");
         assert_eq!(ssh[1], "-t");
         assert_eq!(ssh_tail(&ssh), ["user@box", "miao-server", "attach", "s1"]);
@@ -3877,18 +3897,35 @@ mod tests {
 
         // A socket transport (pooled localhost) needs no ssh hop at all.
         assert_eq!(
-            attach_argv(None, &[], "miao-server", "s1", false),
+            attach_argv(None, &[], "miao-server", "s1", false, &[]),
             ["miao-server", "attach", "s1"]
         );
         // The steal is a flag on the attach, never on the create path.
         assert_eq!(
-            attach_argv(None, &[], "miao-server", "s1", true),
+            attach_argv(None, &[], "miao-server", "s1", true, &[]),
             ["miao-server", "attach", "--force", "s1"]
         );
         // A deployed cache path is invoked in place of `miao-server`.
         let cache = "/home/u/.cache/captain-miao/bin/miao-server";
-        let ssh = attach_argv(Some("user@box"), &[], cache, "s1", false);
+        let ssh = attach_argv(Some("user@box"), &[], cache, "s1", false, &[]);
         assert_eq!(ssh_tail(&ssh), ["user@box", cache, "attach", "s1"]);
+    }
+
+    /// `[remote] inherit_env` runs as one `--inherit-env <NAME>` pair per name on
+    /// the attach, pushed before the session name so the session stays the last
+    /// positional arg.
+    #[test]
+    fn attach_argv_appends_inherit_env() {
+        let inherit = ["ANTHROPIC_API_KEY".to_string()];
+        let ssh = attach_argv(Some("box"), &[], "miao-server", "s1", false, &inherit);
+        let tail = ssh_tail(&ssh);
+        assert!(
+            tail.windows(2)
+                .any(|w| w == ["--inherit-env", "ANTHROPIC_API_KEY"]),
+            "expected contiguous [--inherit-env, ANTHROPIC_API_KEY], got {tail:?}"
+        );
+        // The session name stays the last positional arg, behind the flag pairs.
+        assert_eq!(tail.last(), Some(&"s1".to_string()));
     }
 
     /// The searched *fallback* for the direct-local attach — reached only when
@@ -3938,11 +3975,11 @@ mod tests {
     fn local_attach_argv_is_the_socket_shape() {
         let exe = "/opt/miao/bin/miao-client";
         assert_eq!(
-            attach_argv(None, &[], exe, "cm-claude-9-1", false),
+            attach_argv(None, &[], exe, "cm-claude-9-1", false, &[]),
             [exe, "attach", "cm-claude-9-1"]
         );
         assert_eq!(
-            attach_argv(None, &[], exe, "cm-claude-9-1", true),
+            attach_argv(None, &[], exe, "cm-claude-9-1", true, &[]),
             [exe, "attach", "--force", "cm-claude-9-1"]
         );
     }
@@ -3954,7 +3991,7 @@ mod tests {
     fn local_attach_names_what_is_missing() {
         // Drive the pure resolver, since the real one reads this machine.
         assert!(resolve_local_attach_exe(&[PathBuf::from("/nowhere")], |_| false).is_none());
-        let msg = local_attach_argv("cm-claude-9-1", false)
+        let msg = local_attach_argv("cm-claude-9-1", false, &[])
             .err()
             .map(|e| e.to_string());
         // This machine may genuinely have one installed; only assert the text
@@ -4567,7 +4604,15 @@ mod tests {
         match plan {
             // A socket transport (no ssh target) yields a direct attach window.
             LaunchPlan::AttachRemote { argv, session_name } => {
-                assert_eq!(argv, ["miao-server", "attach", "pool-claude"]);
+                // Only the fixed shape is asserted: the exe name is whichever
+                // pool client this machine has, and `[remote] inherit_env`
+                // threads `--inherit-env NAME` pairs between `attach` and the
+                // session (pinned with explicit values by
+                // `attach_argv_appends_inherit_env`), so an exact argv here
+                // would fail on any machine whose real config sets it.
+                assert_eq!(argv.first().map(String::as_str), Some("miao-server"));
+                assert_eq!(argv.get(1).map(String::as_str), Some("attach"));
+                assert_eq!(argv.last().map(String::as_str), Some("pool-claude"));
                 assert_eq!(session_name, "pool-claude");
             }
             LaunchPlan::SpawnLocal { .. } => panic!("expected AttachRemote from a remote backend"),


### PR DESCRIPTION
libshpool's pty pool starts every pooled session with a scrubbed environment (`env_clear`), so a container-level secret like `ANTHROPIC_OAUTH_TOKEN` that is present for a plain interactive shell **never reaches the pooled agent** — the agent runs inside the pool's session pty, not in the shell that spawned it. Today the only workaround is pasting secrets into each new session by hand.

This adds a local-side knob, `[remote] inherit_env`, listing the *names* of environment variables a pooled session should inherit from the remote host it runs on. Values are opt-in per variable; the default is empty (no change in behavior for anyone who doesn't set it).

```toml
[remote]
inherit_env = ["ANTHROPIC_OAUTH_TOKEN"]
```

## How it works

The value travels as a *name*, never as a secret:

1. The dashboard reads `[remote] inherit_env` from its local `config.toml` at attach time (fresh per attach — no daemon lifecycle staleness).
2. Each name is threaded onto the attach command as `--inherit-env NAME` (one pair per name, session stays the final positional).
3. On the host, `miao-server attach` writes a small libshpool config carrying only `forward_env` and passes it via `--config-file`.
4. libshpool reads each variable **live from the attach process's own environment** — which for a remote pooled session *is* the container's environment — and injects it into the otherwise-scrubbed session pty.

Key property: **the secret is never on disk and never crosses the local→remote boundary in any file**; it rides the existing attach header mechanism. This is deliberately attach-side (not baked into the daemon), so a config edit takes effect on the next session without restarting anything.

## Why `[remote]` and not a daemon-side `env` table

- **Single source of truth per direction.** The daemon config governs session-restore and keybindings (daemon concerns); `forward_env` is a property of the *attach* path, so it lives in the attach client's config.
- **Freshness.** Threading per attach means `[remote] inherit_env` edits apply to the next session without daemon restart or state-file surgery.
- **Least exposure.** Only named variables cross, and only at attach time.

## Design notes

- **Attach-threaded, not daemon-baked.** The attach client resolves values live per attach; stale config can't persist past a session's lifetime.
- **Purely opt-in.** Empty `inherit_env` is byte-identical in behavior to before this change (no `forward_env` written, no flag sent).
- **Upstreamable.** No devcontainer- or deployment-specific naming; the knob is generic ("names of env vars the pooled session should inherit from its host").
- Protocol unchanged — the new flag rides existing attach plumbing, so this is additive across versions.

## Changes

- `crates/cm-core/src/config.rs` — new `[remote] inherit_env: Vec<String>` (`RemoteConfig`, `#[serde(default)]`).
- `crates/cm-server/src/main.rs` — `attach` subcommand gains `--inherit-env` (repeatable).
- `crates/cm-server/src/pty_pool.rs` — `run_attach` authors the libshpool attach config (`forward_env`) and passes `--config-file`; only when the list is non-empty.
- `src/backend/mod.rs` — `attach_argv`/`local_attach_argv` append one `--inherit-env NAME` pair per configured name, keeping the session name the final positional.
- `README.md` / `docs/remote-sessions.md` — documented the knob and its resolution path.

## Testing

- Unit tests: `remote_inherit_env_parses`, `remote_inherit_env_defaults_empty`, `attach_config_body_lists_forward_env`, `attach_argv_appends_inherit_env`.
- `cargo test -p cm-core --lib config`, `cargo test -p captain-miao-server`, `cargo test --bin miao backend::` — all green (82 passed in the backend suite).
- Clippy (`-D warnings`) and fmt clean on all three changed crates.
- **End-to-end on a real pooled remote host** (Linux devcontainer running `miao-server`): with `inherit_env = ["ANTHROPIC_OAUTH_TOKEN"]` set, a pooled session's `printenv` shows the value; with the knob unset, it does not.
